### PR TITLE
Fix generator for Rails 5.0

### DIFF
--- a/lib/generators/versionist/copy_api_version/copy_api_version_generator.rb
+++ b/lib/generators/versionist/copy_api_version/copy_api_version_generator.rb
@@ -56,26 +56,15 @@ module Versionist
       in_root do
         case Versionist.configuration.configured_test_framework
         when :test_unit
-          if File.exists? "test/functional/#{module_name_for_path(old_module_name)}"
-            log "Copying all files from test/functional/#{module_name_for_path(old_module_name)} to test/functional/#{module_name_for_path(new_module_name)}"
-            FileUtils.cp_r "test/functional/#{module_name_for_path(old_module_name)}", "test/functional/#{module_name_for_path(new_module_name)}"
-            Dir.glob("test/functional/#{module_name_for_path(new_module_name)}/*.rb").each do |f|
+          if File.exists? "test/controllers/#{module_name_for_path(old_module_name)}"
+            log "Copying all files from test/controllers/#{module_name_for_path(old_module_name)} to test/controllers/#{module_name_for_path(new_module_name)}"
+            FileUtils.cp_r "test/controllers/#{module_name_for_path(old_module_name)}", "test/controllers/#{module_name_for_path(new_module_name)}"
+            Dir.glob("test/controllers/#{module_name_for_path(new_module_name)}/*.rb").each do |f|
               text = File.read(f)
               File.open(f, 'w') {|f| f << text.gsub(/#{old_module_name}/, new_module_name)}
             end
           else
-            say "No controller tests found in test/functional for #{old_version}"
-          end
-
-          if File.exists? "test/integration/#{module_name_for_path(old_module_name)}"
-            log "Copying all files from test/integration/#{module_name_for_path(old_module_name)} to test/integration/#{module_name_for_path(new_module_name)}"
-            FileUtils.cp_r "test/integration/#{module_name_for_path(old_module_name)}", "test/integration/#{module_name_for_path(new_module_name)}"
-            Dir.glob("test/integration/#{module_name_for_path(new_module_name)}/*.rb").each do |f|
-              text = File.read(f)
-              File.open(f, 'w') {|f| f << text.gsub(/#{old_module_name}/, new_module_name)}
-            end
-          else
-            say "No integration tests found in test/integration for #{old_version}"
+            say "No controller tests found in test/controller for #{old_version}"
           end
         when :rspec
           if File.exists? "spec/controllers/#{module_name_for_path(old_module_name)}"

--- a/lib/generators/versionist/new_api_version/new_api_version_generator.rb
+++ b/lib/generators/versionist/new_api_version/new_api_version_generator.rb
@@ -64,10 +64,8 @@ module Versionist
       in_root do
         case Versionist.configuration.configured_test_framework
         when :test_unit
-          empty_directory "test/functional/#{module_name_for_path(module_name)}"
-          template 'base_controller_functional_test.rb', File.join("test", "functional", "#{module_name_for_path(module_name)}", "base_controller_test.rb")
-          empty_directory "test/integration/#{module_name_for_path(module_name)}"
-          template 'base_controller_integration_test.rb', File.join("test", "integration", "#{module_name_for_path(module_name)}", "base_controller_test.rb")
+          empty_directory "test/controllers/#{module_name_for_path(module_name)}"
+          template 'base_controller_functional_test.rb', File.join("test", "controllers", "#{module_name_for_path(module_name)}", "base_controller_test.rb")
         when :rspec
           @rspec_require_file = rspec_helper_filename
           empty_directory "spec/controllers/#{module_name_for_path(module_name)}"

--- a/lib/generators/versionist/new_api_version/templates/base_controller_functional_test.rb
+++ b/lib/generators/versionist/new_api_version/templates/base_controller_functional_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class <%= module_name %>::BaseControllerTest < ActionController::TestCase
+class <%= module_name %>::BaseControllerTest < ActionDispatch::IntegrationTest
   # Replace this with your real tests.
   test "the truth" do
     assert true

--- a/lib/generators/versionist/new_api_version/templates/base_controller_integration_test.rb
+++ b/lib/generators/versionist/new_api_version/templates/base_controller_integration_test.rb
@@ -1,8 +1,0 @@
-require 'test_helper'
-
-class <%= module_name %>::BaseControllerTest < ActionDispatch::IntegrationTest
-  # Replace this with your real tests.
-  test "the truth" do
-    assert true
-  end
-end

--- a/lib/generators/versionist/new_api_version/templates/base_presenter_test.rb
+++ b/lib/generators/versionist/new_api_version/templates/base_presenter_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class <%= module_name %>::BasePresenterTest < Test::Unit::TestCase
+class <%= module_name %>::BasePresenterTest < ActiveSupport::TestCase
   # Replace this with your real tests.
   test "the truth" do
     assert true

--- a/lib/generators/versionist/new_controller/new_controller_generator.rb
+++ b/lib/generators/versionist/new_controller/new_controller_generator.rb
@@ -32,8 +32,7 @@ module Versionist
       in_root do
         case Versionist.configuration.configured_test_framework
         when :test_unit
-          template 'new_controller_functional_test.rb', File.join("test", "functional", "#{module_name_for_path(module_name)}", "#{file_name}_controller_test.rb")
-          template 'new_controller_integration_test.rb', File.join("test", "integration", "#{module_name_for_path(module_name)}", "#{file_name}_controller_test.rb")
+          template 'new_controller_functional_test.rb', File.join("test", "controllers", "#{module_name_for_path(module_name)}", "#{file_name}_controller_test.rb")
         when :rspec
           @rspec_require_file = rspec_helper_filename
           template 'new_controller_spec.rb', File.join("spec", "controllers", "#{module_name_for_path(module_name)}", "#{file_name}_controller_spec.rb"), :assigns => { :rspec_require_file => @rspec_require_file }

--- a/lib/generators/versionist/new_controller/templates/new_controller_functional_test.rb
+++ b/lib/generators/versionist/new_controller/templates/new_controller_functional_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class <%= module_name %>::<%= class_name%>ControllerTest < ActionController::TestCase
+class <%= module_name %>::<%= class_name%>ControllerTest < ActionDispatch::IntegrationTest
 
   # Replace this with your real tests.
   test "the truth" do

--- a/lib/generators/versionist/new_controller/templates/new_controller_integration_test.rb
+++ b/lib/generators/versionist/new_controller/templates/new_controller_integration_test.rb
@@ -1,9 +1,0 @@
-require 'test_helper'
-
-class <%= module_name %>::<%= class_name%>ControllerTest < ActionDispatch::IntegrationTest
-
-  # Replace this with your real tests.
-  test "the truth" do
-    assert true
-  end
-end

--- a/lib/generators/versionist/new_presenter/templates/new_presenter_test.rb
+++ b/lib/generators/versionist/new_presenter/templates/new_presenter_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class <%= module_name %>::<%= class_name%>PresenterTest < Test::Unit::TestCase
+class <%= module_name %>::<%= class_name%>PresenterTest < ActiveSupport::TestCase
   # Replace this with your real tests.
   test "the truth" do
     assert true


### PR DESCRIPTION
- Functional test files in Rails 5.0 are placed in `test/controllers` folder
- Functional test class in Rails 5.0 is inherited from `ActionDispatch::IntegrationTest`, and also is the integration tests, so integration test template was removed.
- Rails 5 has not more `Test::Unit::TestCase`, use `ActiveSupport::TestCase` instead.
- This fix only include UnitTest part, no chances in Rspec part.

fix https://github.com/bploetz/versionist/issues/80