### PR TITLE
Invoke test_path and older_than_rails_5 methods explicitly in generators

### DIFF
--- a/lib/generators/versionist/copy_api_version/copy_api_version_generator.rb
+++ b/lib/generators/versionist/copy_api_version/copy_api_version_generator.rb
@@ -56,18 +56,18 @@ module Versionist
       in_root do
         case Versionist.configuration.configured_test_framework
         when :test_unit
-          if File.exists? "#{test_path}/#{module_name_for_path(old_module_name)}"
-            log "Copying all files from #{test_path}/#{module_name_for_path(old_module_name)} to #{test_path}/#{module_name_for_path(new_module_name)}"
-            FileUtils.cp_r "#{test_path}/#{module_name_for_path(old_module_name)}", "#{test_path}/#{module_name_for_path(new_module_name)}"
-            Dir.glob("#{test_path}/#{module_name_for_path(new_module_name)}/*.rb").each do |f|
+          if File.exists? "#{Versionist.test_path}/#{module_name_for_path(old_module_name)}"
+            log "Copying all files from #{Versionist.test_path}/#{module_name_for_path(old_module_name)} to #{Versionist.test_path}/#{module_name_for_path(new_module_name)}"
+            FileUtils.cp_r "#{Versionist.test_path}/#{module_name_for_path(old_module_name)}", "#{Versionist.test_path}/#{module_name_for_path(new_module_name)}"
+            Dir.glob("#{Versionist.test_path}/#{module_name_for_path(new_module_name)}/*.rb").each do |f|
               text = File.read(f)
               File.open(f, 'w') {|f| f << text.gsub(/#{old_module_name}/, new_module_name)}
             end
           else
-            say "No tests found in #{test_path} for #{old_version}"
+            say "No tests found in #{Versionist.test_path} for #{old_version}"
           end
 
-          if older_than_rails_5?
+          if Versionist.older_than_rails_5?
             if File.exists? "test/integration/#{module_name_for_path(old_module_name)}"
               log "Copying all files from test/integration/#{module_name_for_path(old_module_name)} to test/integration/#{module_name_for_path(new_module_name)}"
               FileUtils.cp_r "test/integration/#{module_name_for_path(old_module_name)}", "test/integration/#{module_name_for_path(new_module_name)}"

--- a/lib/generators/versionist/new_api_version/new_api_version_generator.rb
+++ b/lib/generators/versionist/new_api_version/new_api_version_generator.rb
@@ -64,14 +64,14 @@ module Versionist
       in_root do
         case Versionist.configuration.configured_test_framework
         when :test_unit
-          empty_directory "test/#{test_path}/#{module_name_for_path(module_name)}"
+          empty_directory "test/#{Versionist.test_path}/#{module_name_for_path(module_name)}"
           empty_directory "test/integration/#{module_name_for_path(module_name)}"
 
-          if older_than_rails_5?
+          if Versionist.older_than_rails_5?
             template 'base_controller_integration_test.rb', File.join("test", "integration", "#{module_name_for_path(module_name)}", "base_controller_test.rb")
-            template 'base_controller_functional_test.rb', File.join("test", "#{test_path}", "#{module_name_for_path(module_name)}", "base_controller_test.rb")
+            template 'base_controller_functional_test.rb', File.join("test", "#{Versionist.test_path}", "#{module_name_for_path(module_name)}", "base_controller_test.rb")
           else
-            template 'base_controller_functional_test_rails_5.rb', File.join("test", "#{test_path}", "#{module_name_for_path(module_name)}", "base_controller_test_rails_5.rb")
+            template 'base_controller_functional_test_rails_5.rb', File.join("test", "#{Versionist.test_path}", "#{module_name_for_path(module_name)}", "base_controller_test_rails_5.rb")
           end
         when :rspec
           @rspec_require_file = rspec_helper_filename
@@ -98,7 +98,7 @@ module Versionist
         when :test_unit
           empty_directory "test/presenters/#{module_name_for_path(module_name)}"
 
-          if older_than_rails_5?
+          if Versionist.older_than_rails_5?
             template 'base_presenter_test.rb', File.join("test", "presenters", "#{module_name_for_path(module_name)}", "base_presenter_test.rb")
           else
             template 'base_presenter_test_rails_5.rb', File.join("test", "presenters", "#{module_name_for_path(module_name)}", "base_presenter_test_rails_5.rb")

--- a/lib/generators/versionist/new_controller/new_controller_generator.rb
+++ b/lib/generators/versionist/new_controller/new_controller_generator.rb
@@ -32,11 +32,11 @@ module Versionist
       in_root do
         case Versionist.configuration.configured_test_framework
         when :test_unit
-          if older_than_rails_5?
+          if Versionist.older_than_rails_5?
             template 'new_controller_integration_test.rb', File.join("test", "integration", "#{module_name_for_path(module_name)}", "#{file_name}_controller_test.rb")
-            template 'new_controller_functional_test.rb', File.join("test", "#{test_path}", "#{module_name_for_path(module_name)}", "#{file_name}_controller_test.rb")
+            template 'new_controller_functional_test.rb', File.join("test", "#{Versionist.test_path}", "#{module_name_for_path(module_name)}", "#{file_name}_controller_test.rb")
           else
-            template 'new_controller_functional_test_rails_5.rb', File.join("test", "#{test_path}", "#{module_name_for_path(module_name)}", "#{file_name}_controller_test_rails_5.rb")
+            template 'new_controller_functional_test_rails_5.rb', File.join("test", "#{Versionist.test_path}", "#{module_name_for_path(module_name)}", "#{file_name}_controller_test_rails_5.rb")
           end
         when :rspec
           @rspec_require_file = rspec_helper_filename

--- a/lib/generators/versionist/new_presenter/new_presenter_generator.rb
+++ b/lib/generators/versionist/new_presenter/new_presenter_generator.rb
@@ -19,7 +19,7 @@ module Versionist
       in_root do
         case Versionist.configuration.configured_test_framework
         when :test_unit
-          if older_than_rails_5?
+          if Versionist.older_than_rails_5?
             template 'new_presenter_test.rb', File.join("test", "presenters", "#{module_name_for_path(module_name)}", "#{file_name}_presenter_test.rb")
           else
             template 'new_presenter_test_rails_5.rb', File.join("test", "presenters", "#{module_name_for_path(module_name)}", "#{file_name}_presenter_test_rails_5.rb")


### PR DESCRIPTION
The generators were failing in Rails 5.1 due to the implicit calls to `test_path` and `older_than_rails_5?`
This commit fixes the generators by making explicit calls to `Versionist.test_path` and `Versionist.older_than_rails_5?`