### PR TITLE
Bump Yard to ~> 0.9.20 to address vulnerability

### DIFF
--- a/lib/versionist/version.rb
+++ b/lib/versionist/version.rb
@@ -1,3 +1,3 @@
 module Versionist
-  VERSION = '2.0.0'
+  VERSION = '2.0.1'
 end

--- a/versionist.gemspec
+++ b/versionist.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'railties', '>= 3'
   s.add_dependency 'activesupport', '>= 3'
 
-  s.add_dependency('yard', "~> 0.9.11")
+  s.add_dependency('yard', "~> 0.9.20")
 end


### PR DESCRIPTION
See https://github.com/lsegal/yard/security/advisories/GHSA-xfhh-rx56-rxcr